### PR TITLE
python3-pyocd v0.35.1

### DIFF
--- a/images/ppc-sbc-test-image.bb
+++ b/images/ppc-sbc-test-image.bb
@@ -13,3 +13,4 @@ inherit core-image
 
 IMAGE_INSTALL:append = " packagegroup-ppc-sbc"
 IMAGE_INSTALL:append = " python3-intelhex"
+IMAGE_INSTALL:append = " python3-pyocd"

--- a/recipes-devtools/python3-pyocd/python3-capstone_4.0.2.bb
+++ b/recipes-devtools/python3-pyocd/python3-capstone_4.0.2.bb
@@ -1,0 +1,14 @@
+# python3-capstone
+SUMMARY = "Capstone disassembly enginde"
+HOMEPAGE ="http://www.capstone-engine.org/"
+LIC_FILES_CHKSUM = "file://LICENSE.TXT;md5=1cfbff4f40612b0144e498a47c91499c"
+LICENSE = "BSD-3-Clause"
+
+PYPI_PACKAGE = "capstone"
+SRC_URI[sha256sum] = "2842913092c9b69fd903744bc1b87488e1451625460baac173056e1808ec1c66"
+
+inherit pypi setuptools3
+
+do_install:append() {
+	rm -f ${D}/usr/lib/python3.11/site-packages/capstone/lib/libcapstone.a
+}

--- a/recipes-devtools/python3-pyocd/python3-importlib-resources_5.12.0.bb
+++ b/recipes-devtools/python3-pyocd/python3-importlib-resources_5.12.0.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Read resources from Python packages"
+HOMEPAGE = "https://pypi.org/project/importlib-resources/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+
+inherit pypi python_setuptools_build_meta
+
+PYPI_PACKAGE = "importlib_resources"
+UPSTREAM_CHECK_REGEX = "/importlib-resources/(?P<pver>(\d+[\.\-_]*)+)/"
+
+SRC_URI[sha256sum] = "4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"
+
+S = "${WORKDIR}/importlib_resources-${PV}"
+
+DEPENDS += "${PYTHON_PN}-setuptools-scm-native ${PYTHON_PN}-toml-native"
+#RDEPENDS:${PN} += "${PYTHON_PN}-zipp ${PYTHON_PN}-pathlib2"
+RDEPENDS:${PN}:append:class-target = " python3-misc"
+RDEPENDS:${PN}:append:class-nativesdk = " python3-misc"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/python3-pyocd/python3-intervaltree_3.1.0.bb
+++ b/recipes-devtools/python3-pyocd/python3-intervaltree_3.1.0.bb
@@ -1,0 +1,12 @@
+# python3-intervaltree
+SUMMARY = "Editable interval tree data structure for Python 2 and 3"
+HOMEPAGE ="https://pypi.org/project/intervaltree"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=3b83ef96387f14655fc854ddc3c6bd57"
+LICENSE = "Apache-2.0"
+
+PYPI_PACKAGE = "intervaltree"
+SRC_URI[sha256sum] = "902b1b88936918f9b2a19e0e5eb7ccb430ae45cde4f39ea4b36932920d33952d"
+
+inherit pypi setuptools3
+
+RDEPENDS:${PN} += " python3-sortedcontainers"

--- a/recipes-devtools/python3-pyocd/python3-lark_1.1.5.bb
+++ b/recipes-devtools/python3-pyocd/python3-lark_1.1.5.bb
@@ -1,0 +1,10 @@
+# python3-lark
+SUMMARY = "Python package for a modern parsing library"
+HOMEPAGE ="https://pypi.org/project/lark"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=fcfbf1e2ecc0f37acbb5871aa0267500"
+
+PYPI_PACKAGE = "lark"
+SRC_URI[sha256sum] = "4b534eae1f9af5b4ea000bea95776350befe1981658eea3820a01c37e504bb4d"
+
+inherit pypi setuptools3

--- a/recipes-devtools/python3-pyocd/python3-libusb-package_1.0.26.1.bb
+++ b/recipes-devtools/python3-pyocd/python3-libusb-package_1.0.26.1.bb
@@ -1,0 +1,12 @@
+# python3-libusb-package
+SUMMARY = "Package containing libusb so it can be installed via Python package managers"
+HOMEPAGE ="https://pypi.org/project/libusb-package"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=e23fadd6ceef8c618fc1c65191d846fa"
+LICENSE = "Apache-2.0"
+
+PYPI_PACKAGE = "libusb-package"
+SRC_URI[sha256sum] = "5a586744a59e3870791c28f964568e211f5f44bb398ccb51b25f3565dd4666ad"
+
+inherit pypi setuptools3
+
+DEPENDS += " python3-setuptools-scm-native"

--- a/recipes-devtools/python3-pyocd/python3-pylink-square_1.0.0.bb
+++ b/recipes-devtools/python3-pyocd/python3-pylink-square_1.0.0.bb
@@ -1,0 +1,21 @@
+# python3-pylink-square
+SUMMARY = "Python interface for SEGGER J-Link"
+HOMEPAGE ="https://pypi.org/project/pylink-square"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=834c4b2cb72db13143b58bebff15bafb"
+LICENSE = "Apache-2.0"
+
+PYPI_PACKAGE = "pylink-square"
+SRC_URI[sha256sum] = "c91261ae19a7ef6c70fda24f06da98272b27518dd71472c709e170afdee89f88"
+
+inherit pypi setuptools3
+
+DEPENDS += " python3-six-native"
+
+RDEPENDS:${PN} += " python3-future"
+RDEPENDS:${PN} += " python3-setuptools"
+
+# To use SEGGER J-Link runtime library in pylink-square:
+# ```
+# export LD_LIBRARY_PATH="/opt/SEGGER/JLink:$LD_LIBRARY_PATH"
+# ```
+#RRECOMMENDS:${PN} += " segger-jlink"

--- a/recipes-devtools/python3-pyocd/python3-pyocd-pemicro_1.1.5.bb
+++ b/recipes-devtools/python3-pyocd/python3-pyocd-pemicro_1.1.5.bb
@@ -1,0 +1,10 @@
+# python3-pyocd-pemicro
+SUMMARY = "PEMicro probe plugin for pyOCD"
+HOMEPAGE ="https://github.com/pyocd/pyocd-pemicro"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f6751a0652c0033100252953bfcf00d2"
+
+PYPI_PACKAGE = "pyocd-pemicro"
+SRC_URI[sha256sum] = "fc3e7c8bfcf3acd4902d32e3c06ad87347a1cb0a6a9324d8bfda80eda78ca024"
+
+inherit pypi setuptools3

--- a/recipes-devtools/python3-pyocd/python3-pyocd_0.35.1.bb
+++ b/recipes-devtools/python3-pyocd/python3-pyocd_0.35.1.bb
@@ -1,0 +1,37 @@
+# python3-pyocd
+SUMMARY = "Cortex-M debugger for Python"
+DESCRIPTION = "\
+  pyOCD is an open source Python based tool and package for \
+  programming and debugging Arm Cortex-M microcontrollers with \
+  a wide range of debug probes. \
+"
+HOMEPAGE = "https://pyocd.io/"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=421492e27872cb498685e9d7649f63a2"
+
+PYPI_PACKAGE = "pyocd"
+SRC_URI[sha256sum] = "02e8084f4d3b26d4d7c7470bb470fd4edc6c2bf2ba781e3dd94da4f84571c975"
+
+inherit pypi setuptools3
+
+RDEPENDS:${PN} += " python3-setuptools"
+
+RDEPENDS:${PN} += " python3-capstone"
+#RDEPENDS:${PN} += " python3-cmsis-pack-manager"
+RDEPENDS:${PN} += " python3-colorama"
+RDEPENDS:${PN} += " python3-importlib-metadata"
+RDEPENDS:${PN} += " python3-importlib-resources"
+RDEPENDS:${PN} += " python3-intelhex"
+RDEPENDS:${PN} += " python3-intervaltree"
+RDEPENDS:${PN} += " python3-lark"
+RDEPENDS:${PN} += " python3-libusb-package"
+RDEPENDS:${PN} += " python3-natsort"
+RDEPENDS:${PN} += " python3-prettytable"
+RDEPENDS:${PN} += " python3-pyelftools"
+RDEPENDS:${PN} += " python3-pylink-square"
+RDEPENDS:${PN} += " python3-pyusb"
+RDEPENDS:${PN} += " python3-pyyaml"
+RDEPENDS:${PN} += " python3-six"
+
+#RRECOMMENDS:${PN} += " segger-jlink"
+RRECOMMENDS:${PN} += " python3-pyocd-pemicro"


### PR DESCRIPTION
Add BitBake recipies for pyocd and supporting python packages:
- python3-capstone_4.0.2.bb
- python3-importlib-resources_5.12.0.bb
- python3-intervaltree_3.1.0.bb
- python3-lark_1.1.5.bb
- python3-libusb-package_1.0.26.1.bb
- python3-pylink-square_1.0.0.bb
- python3-pyocd-pemicro_1.1.5.bb
- python3-pyocd_0.35.1.bb