### PR TITLE
python3-spsdk: 1.11.0 -> 2.0.0

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -11,7 +11,7 @@ BBFILE_PATTERN_bcdevices = "^${LAYERDIR}/"
 BBFILE_PRIORITY_bcdevices = "5"
 
 LAYERVERSION_bcdevices = "1"
-LAYERSERIES_COMPAT_bcdevices = "dunfell kirkstone langdale mickledore nanbield"
+LAYERSERIES_COMPAT_bcdevices = "dunfell kirkstone langdale mickledore nanbield scarthgap"
 
 LAYERDEPENDS_bcdevices = "core"
 

--- a/recipes-devtools/python3-spsdk/python3-spsdk_2.0.0.bb
+++ b/recipes-devtools/python3-spsdk/python3-spsdk_2.0.0.bb
@@ -9,7 +9,7 @@ DESCRIPTION = "\
 HOMEPAGE = "https://github.com/nxp-mcuxpresso/spsdk"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=6c72a66edfa65948c15795224be74979"
-SRC_URI[sha256sum] = "03d8821ad05a0149a107b9ddfc01371f6894d02ada36e1065b0efd9301526854"
+SRC_URI[sha256sum] = "1eab78cab1d77b4220845ef223e4b82c84fbe92cecd8ae01c6ab8a7dda183c32"
 
 PYPI_PACKAGE = "spsdk"
 


### PR DESCRIPTION
Update to SPSDK 2.0.0 (from 1.11.0)

Release notes:

https://github.com/nxp-mcuxpresso/spsdk/releases/tag/2.0.0