### PR TITLE
pltagent-msc-host: RDEPENDS coreutils

### DIFF
--- a/recipes-mfgtools/pltagent-msc-host/pltagent-msc-host.bb
+++ b/recipes-mfgtools/pltagent-msc-host/pltagent-msc-host.bb
@@ -31,6 +31,7 @@ DEPENDS += " pltagent"
 #DEPENDS += " wic-tools"
 
 RDEPENDS:${PN} += " bash"
+RDEPENDS:${PN} += " coreutils"
 RDEPENDS:${PN} += " dosfstools"
 RDEPENDS:${PN} += " parted"
 #RDEPENDS:${PN} += " pltagent-prog"


### PR DESCRIPTION
Fixed `Config c/1 of pltagent needs at least one function.` error.