### PR TITLE
Remove ``S = "${WORKDIR}``

### DIFF
--- a/recipes-mfgtools/pltagent-msc-host/pltagent-msc-host.bb
+++ b/recipes-mfgtools/pltagent-msc-host/pltagent-msc-host.bb
@@ -14,7 +14,8 @@ SRC_URI = "\
   file://pltagent-usbgadget-handler.sh \
 "
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 FILES:${PN} += " /opt/pltagent/bin/pltagent-msc-mount"
 FILES:${PN} += " /opt/pltagent/bin/pltagent-msc-mount"
@@ -71,7 +72,7 @@ SRC_URI:append = " file://pltagent-msc.service "
 
 do_install:append() {
         install -d ${D}/${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/pltagent-msc.service ${D}/${systemd_unitdir}/system
+        install -m 0644 ${S}/pltagent-msc.service ${D}/${systemd_unitdir}/system
 }
 
 FILES:${PN} += "${systemd_unitdir}/system"

--- a/recipes-mfgtools/pltagent/pltagent.bb
+++ b/recipes-mfgtools/pltagent/pltagent.bb
@@ -21,7 +21,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384
 
 SRC_URI = "file://pltagent-profile"
 
-S = "${WORKDIR}"
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
 
 inherit allarch
 inherit useradd
@@ -34,7 +35,7 @@ GROUPMEMS_PARAM:${PN} = "-g audio -a pltagent; -g plugdev -a pltagent"
 
 do_install () {
 	install -d 755 ${D}${localstatedir}/lib/${BPN}
-	install -m 644 ${WORKDIR}/${BPN}-profile ${D}${localstatedir}/lib/${BPN}/.profile
+	install -m 644 ${S}/${BPN}-profile ${D}${localstatedir}/lib/${BPN}/.profile
 	chown -R pltagent:adm ${D}${localstatedir}/lib/${BPN}
 }
 
@@ -51,5 +52,5 @@ FILES:${PN} += "${systemd_unitdir}/system/pltagent.service"
 
 do_install:append() {
         install -d ${D}/${systemd_unitdir}/system
-        install -m 0644 ${WORKDIR}/pltagent.service ${D}/${systemd_unitdir}/system
+        install -m 0644 ${S}/pltagent.service ${D}/${systemd_unitdir}/system
 }

--- a/recipes-mfgtools/pltagent/systemd-serialgetty.bbappend
+++ b/recipes-mfgtools/pltagent/systemd-serialgetty.bbappend
@@ -3,5 +3,5 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 SRC_URI:append = " file://serial-getty@.service"
 
 do_install:append() {
-	install -m 0644 ${WORKDIR}/serial-getty@.service ${D}${systemd_system_unitdir}/
+	install -m 0644 ${S}/serial-getty@.service ${D}${systemd_system_unitdir}/
 }


### PR DESCRIPTION
Remove deprecated usage of ``S = "${WORKDIR}``